### PR TITLE
v0: attendence: fix bug for attendence count

### DIFF
--- a/api/v0/attendence.php
+++ b/api/v0/attendence.php
@@ -112,7 +112,7 @@ function getAttendence($event_id = null) {
             }
             switch ($row['attendence']) {
                 case 0:
-                    $refusal = intval($row['COUNT(*)']);
+                    $refusal += intval($row['COUNT(*)']); //count refusal/plusone with 0/0 and 0/1
                     break;
                 case 1:
                     if($row['plusone'] == 1)


### PR DESCRIPTION
when a member checked plusone and later excused himself from the event, only the refuse+plusones would be counted as refusal
