### PR TITLE
eventinfo: add missing return value

### DIFF
--- a/api/eventinfo.php
+++ b/api/eventinfo.php
@@ -157,5 +157,7 @@ function getEntries($api_token, $event_id)
     }
 
     response_with_data(200, $entries);
+
+    return true;
 }
 ?>


### PR DESCRIPTION
missing return value caused false return, triggering an 500 error code, which is in turn unable to be send, as output was already given
